### PR TITLE
Added repository to allow 'vagrant up' to work correctly

### DIFF
--- a/vagrant-install.sh
+++ b/vagrant-install.sh
@@ -42,3 +42,7 @@ sudo service apache2 restart
 # file permissions set
 find /vagrant -type d -exec chmod 755 {} \;
 find /vagrant -type f -exec chmod 644 {} \;
+
+#Useful tools
+sudo apt-get -y install vim
+sudo apt-get -y install tmux

--- a/vagrant-install.sh
+++ b/vagrant-install.sh
@@ -12,13 +12,14 @@ sudo apt-get install -y python-software-properties
 sudo apt-get update
 
 sudo add-apt-repository -y ppa:ondrej/php5
+sudo apt-add-repository -y ppa:ptn107/apache
 
 sudo apt-get update
 
 # install apps
 sudo apt-get install -y php5 apache2 libapache2-mod-php5
 sudo apt-get install -y mysql-server-5.5
-sudo apt-get install -y php5-mysql 
+sudo apt-get install -y php5-mysql
 sudo apt-get install -y php5-gd php5-mcrypt git-core php5-curl
 
 sudo a2enmod rewrite
@@ -41,4 +42,3 @@ sudo service apache2 restart
 # file permissions set
 find /vagrant -type d -exec chmod 755 {} \;
 find /vagrant -type f -exec chmod 644 {} \;
-


### PR DESCRIPTION
The installation of Apache2 fails during 'vagrant up' unless you add the repo I have included. This is probably because of diverging dependency chains.

Also installs tmux and vim for use when the box is up and running